### PR TITLE
tests: link settings_test_fs with kernel

### DIFF
--- a/tests/subsys/settings/fs/src/CMakeLists.txt
+++ b/tests/subsys/settings/fs/src/CMakeLists.txt
@@ -12,3 +12,4 @@ add_dependencies(settings_test_fs
 
 FILE(GLOB fssources *.c )
 zephyr_library_sources(${fssources})
+zephyr_library_link_libraries(kernel)


### PR DESCRIPTION
This is patch to #29618 to specifically link settings_test_fs with
kernel library.

This is needed because Zephyr libraries created after
`find_package(Zephyr)` are not pure Zephyr libraries, as they are not
in the `whole-archive` linking grouping.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>